### PR TITLE
fix: sign long message

### DIFF
--- a/rust/navigator/src/tests.rs
+++ b/rust/navigator/src/tests.rs
@@ -130,7 +130,7 @@ fn signature_is_good(transaction_hex: &str, signature_hex: &str) -> bool {
                 }
             };
             let message = {
-                if message.len() > 257 {
+                if message.len() > 257 && &transaction_hex[4..6] != "03" {
                     blake2b(32, &[], &message).as_bytes().to_vec()
                 } else {
                     message
@@ -163,7 +163,7 @@ fn signature_is_good(transaction_hex: &str, signature_hex: &str) -> bool {
                 }
             };
             let message = {
-                if message.len() > 257 {
+                if message.len() > 257 && &transaction_hex[4..6] != "03" {
                     blake2b(32, &[], &message).as_bytes().to_vec()
                 } else {
                     message
@@ -196,7 +196,7 @@ fn signature_is_good(transaction_hex: &str, signature_hex: &str) -> bool {
                 }
             };
             let message = {
-                if message.len() > 257 {
+                if message.len() > 257 && &transaction_hex[4..6] != "03" {
                     blake2b(32, &[], &message).as_bytes().to_vec()
                 } else {
                     message

--- a/rust/transaction_signing/src/sign_transaction.rs
+++ b/rust/transaction_signing/src/sign_transaction.rs
@@ -29,20 +29,18 @@ pub(crate) fn create_signature(
     };
     let content_vec = match sign.content() {
         SignContent::Transaction { method, extensions } => {
-            [method.to_vec(), extensions.to_vec()].concat()
+        // For larger transactions, their hash should be signed instead; this is not 
+        // implemented upstream so we put it here
+            let whole_vec = [method.to_vec(), extensions.to_vec()].concat();
+            if whole_vec.len() > 257 {
+                blake2b(32, &[], &whole_vec).as_bytes().to_vec()
+            } else {
+                whole_vec
+            }
         }
         SignContent::Message(a) => format!("<Bytes>{}</Bytes>", a).into_bytes(),
     };
 
-    // For larger transactions, their hash should be signed instead; this is not implemented
-    // upstream so we put it here
-    let content_vec = {
-        if content_vec.len() > 257 {
-            blake2b(32, &[], &content_vec).as_bytes().to_vec()
-        } else {
-            content_vec
-        }
-    };
     let mut full_address = seed_phrase.to_owned() + &sign.path();
     match sign_as_address_key(&content_vec, &sign.multisigner(), &full_address, pwd) {
         Ok(s) => {

--- a/rust/transaction_signing/src/sign_transaction.rs
+++ b/rust/transaction_signing/src/sign_transaction.rs
@@ -29,8 +29,8 @@ pub(crate) fn create_signature(
     };
     let content_vec = match sign.content() {
         SignContent::Transaction { method, extensions } => {
-        // For larger transactions, their hash should be signed instead; this is not 
-        // implemented upstream so we put it here
+            // For larger transactions, their hash should be signed instead; this is not
+            // implemented upstream so we put it here
             let whole_vec = [method.to_vec(), extensions.to_vec()].concat();
             if whole_vec.len() > 257 {
                 blake2b(32, &[], &whole_vec).as_bytes().to_vec()


### PR DESCRIPTION
Messages are not hashed before signing, unlike transactions longer than some limit